### PR TITLE
Detect if agent is installed on the zabbix server

### DIFF
--- a/root/etc/e-smith/templates/etc/zabbix/zabbix_agentd.conf/20zabbix
+++ b/root/etc/e-smith/templates/etc/zabbix/zabbix_agentd.conf/20zabbix
@@ -145,8 +145,13 @@ ServerActive={${'zabbix-agent'}{'ServerZabbix'}||'127.0.0.1'}
 # Mandatory: no
 # Default:
 # Hostname=
-
-Hostname={$SystemName}.{$DomainName}
+{
+  if ( -f "/etc/e-smith/db/configuration/defaults/zabbix-server/status") {
+    $OUT .= "Hostname=Zabbix server"
+  } else {
+    $OUT .= "Hostname=$SystemName.$DomainName"
+  }
+}
 
 ### Option: HostnameItem
 #	Item used for generating Hostname if it is undefined. Ignored if Hostname is defined.


### PR DESCRIPTION
Find if the agent is installed on the server zabbix if yes use `Zabbix server` to avoid the error on the host not know in the agent log