### PR TITLE
Force the creation of the run directory

### DIFF
--- a/root/etc/systemd/system/zabbix-agent.service.d/nethserver.conf
+++ b/root/etc/systemd/system/zabbix-agent.service.d/nethserver.conf
@@ -1,0 +1,3 @@
+[Service]
+RuntimeDirectory=zabbix
+RuntimeDirectoryMode=0755

--- a/root/etc/systemd/system/zabbix-agent2.service.d/nethserver.conf
+++ b/root/etc/systemd/system/zabbix-agent2.service.d/nethserver.conf
@@ -1,0 +1,3 @@
+[Service]
+RuntimeDirectory=zabbix
+RuntimeDirectoryMode=0755


### PR DESCRIPTION
When the /var/run/zabbix is deleted the service fails to start because it misses its run folder.

With this commit, systemd creates the folder