### PR TITLE
Add sudo requirements to agent for listing rpm

### DIFF
--- a/root/etc/sudoers.d/50_nsapi_nethserver_zabbix_agent
+++ b/root/etc/sudoers.d/50_nsapi_nethserver_zabbix_agent
@@ -1,0 +1,7 @@
+#
+# nsapi_nethserver_zabbix_agent
+#
+
+zabbix ALL= NOPASSWD: /usr/bin/rpm -qa
+
+Defaults!NSAPI_NETHSERVER_ZABBIX !requiretty


### PR DESCRIPTION
We can find in log some noises with agent2

```
/var/log/zabbix/zabbix_agent2.log:123:2021/03/25 21:45:23.413557 [Sw] Failed to execute command 'rpm -qa', err: Timeout while executing a shell script.
```

agent2 tries to collect rpms to check upgrade or software installation