### PR TITLE
 Keep other 3th party repos enabled as much as possible

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -12,12 +12,12 @@ use esmith::Build::CreateLinks qw(:all);
 my $event = 'nethserver-zabbix-agent-update';
 event_actions ($event,
      'initialize-default-databases' => '00',
-     'nethserver-zabbix-agent_enablerepo' => '10',
      'nethserver-zabbix-agent-conf' => '10'
 );
 
 templates2events("/etc/zabbix/zabbix_agentd.conf", $event);
 templates2events("/etc/zabbix/zabbix_agent2.conf", $event);
+templates2events("/etc/nethserver/eorepo.conf", $event);
 
 event_services($event,
                'zabbix-agent' => 'restart',

--- a/root/etc/e-smith/events/actions/nethserver-zabbix-agent_enablerepo
+++ b/root/etc/e-smith/events/actions/nethserver-zabbix-agent_enablerepo
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo '[NOTICE] applying new YUM repository configuration'
-exec /sbin/e-smith/signal-event software-repos-save


### PR DESCRIPTION
- Omit running signal-event software-repos-save explicitly

One does not need to run signal-event software-repos-save to install and enable the required repo.
Running software-repos-save often confuses people, especially on non-subscription, as it disables all repositories not listed in /etc/nethserver/eorepo.conf

Also see:
stephdl/dev#18